### PR TITLE
Index rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Synoindex Watcher - Automated media index updates
 
-Synoindex Watcher is a media index updater for Synology DiskStations based on inotify and synoindex. It watches the
-media-folders of your DiskStation an updates the media index every time a file or directory inside the media-folders is
-created, deleted or changed. It is written in Python and licensed as open-source under the GPL version 3.
+Synoindex Watcher is a media index updater for Synology DiskStations based on inotify and synoindex. It watches the media-folders of your DiskStation an updates the media index every time a file or directory inside the media-folders is created, deleted or changed. It is written in Python and licensed as open-source under the GPL version 3.
 
-The original version was written by Mark Houghton, who [published it in his "codesourcery"
-blog](https://codesourcery.wordpress.com/2012/11/29/more-on-the-synology-nas-automatically-indexing-new-files/).
+The original version was written by Mark Houghton, who [published it in his "codesourcery" blog](https://codesourcery.wordpress.com/2012/11/29/more-on-the-synology-nas-automatically-indexing-new-files/).
 
 ## Features
 
@@ -15,9 +12,7 @@ blog](https://codesourcery.wordpress.com/2012/11/29/more-on-the-synology-nas-aut
 
 ## Installation
 
-Synoindex Watcher cannot be installed via Synology's Package Center. You have to log in via SSH and use the terminal.
-I recommend to use pip for the installation. Synology DiskStations do not have pip installed by default, but you can
-add it easily with the following command:
+Synoindex Watcher cannot be installed via Synology's Package Center. You have to log in via SSH and use the terminal.  I recommend to use pip for the installation. Synology DiskStations do not have pip installed by default, but you can add it easily with the following command:
 
 ```
 $ wget https://bootstrap.pypa.io/get-pip.py -qO - | sudo python
@@ -104,17 +99,11 @@ $ python -m synoindexwatcher --generate-init --config=/usr/local/etc/synoindexwa
 
 ### I'm getting `OSError: [Errno 28] No space left on device`
 
-This actually does not mean that you run out of disk space, but rather that your system does not allow enough
-inode-watchers to watch all your media files. The message is quite confusing, though.
+This actually does not mean that you run out of disk space, but rather that your system does not allow enough inode-watchers to watch all your media files. The message is quite confusing, though.
 
-To fix this temporarily you could simply type `echo 204800 > /proc/sys/fs/inotify/max_user_watches` as root. The maximum
-number of inode-watchers in the user-space would be 204800 afterwards, which should be enough for most use-cases.
-Unfortunately this fixes the problem only until the next reboot.
+To fix this temporarily you could simply type `echo 204800 > /proc/sys/fs/inotify/max_user_watches` as root. The maximum number of inode-watchers in the user-space would be 204800 afterwards, which should be enough for most use-cases.  Unfortunately this fixes the problem only until the next reboot.
 
-For a permanent solution it is recommended to add the line `fs.inotify.max_user_watches = 204800` to the file
-*/etc/sysctl.conf*. This should set the maximum value during boot, but I had to add an init-script that executes
-`sysctl -p /etc/sysctl.conf` to make it work. The simplest way would be to add the command to the start-section of the
-init-script for Synonindex Watcher.
+For a permanent solution it is recommended to add the line `fs.inotify.max_user_watches = 204800` to the file */etc/sysctl.conf*. This should set the maximum value during boot, but I had to add an init-script that executes `sysctl -p /etc/sysctl.conf` to make it work. The simplest way would be to add the command to the start-section of the init-script for Synonindex Watcher.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The default behaviour of Synoindex Watcher can be changed with various command-l
 
 * `--config=file`: Get the default-configuration from a certain file. For example `python -m synoindexwatcher --config=/etc/synoindexwatcher.conf` will tell Synoindex Watcher to use the values in */etc/synoindexwatcher.conf* as its default-values. Any additional command-line arguments will override the values read from the configuration-file.
 
+* `--rebuild-index`: Empty the media-index database, add all allowed files and directories in the watched directories and exit afterwards. Be careful with this argument as it destroys your current index and might take a long time to complete. Use it if your media-index contains deleted files or lacks existing files.
+
 * `--generate-init`: Generate an init-script, write it to the standard output and exit afterwards. Any additional command-line arguments will be integrated into the generated script. See the [start on boot](#start-on-boot) section above for further details.
 
 * `--generate-config`: Generate a configuration-file, write it to the standard output and exit afterwards. Any additional command-line arguments will be integrated into the generated configuration. See the [configuration-file](#configuration-file) section below for further details.


### PR DESCRIPTION
This PR adds the `--rebuild-index` arguments (see the docs for further details on how it works). Apart from that also some refactoring has taken place.

Please note that the loglevel of messages when `synoindex` has been called has been demoted from `INFO` to `DEBUG`.