### PR TITLE
Use future to support input as string on both python 2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
     ],
     install_requires=[
         "inotifyrecursive>=0.3.3",
+        "future",
         "configparser; python_version < '3.5'"
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*"

--- a/synoindexwatcher/__main__.py
+++ b/synoindexwatcher/__main__.py
@@ -28,6 +28,7 @@ import configparser
 import re
 
 from inotifyrecursive import INotify, flags
+from builtins import input
 
 from . import constants
 from . import files


### PR DESCRIPTION
Import input from the builtins module provided by the future package to support raw_input style input in python 2. This addresses issue #40.