### PR TITLE
No meddling with database

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The default behaviour of Synoindex Watcher can be changed with various command-l
 
 * `--config=file`: Get the default-configuration from a certain file. For example `python -m synoindexwatcher --config=/etc/synoindexwatcher.conf` will tell Synoindex Watcher to use the values in */etc/synoindexwatcher.conf* as its default-values. Any additional command-line arguments will override the values read from the configuration-file.
 
-* `--rebuild-index`: Empty the media-index database, add all allowed files and directories in the watched directories and exit afterwards. Be careful with this argument as it destroys your current index and might take a long time to complete. Use it if your media-index contains deleted files or lacks existing files.
+* `--rebuild-index`: Add all allowed files and directories in the watched directories and exit afterwards. Use it, if your media-index lacks entries for existing files. Read the [related FAQ-entry](#the-media-index-contains-entries-for-files-that-do-not-exist), if you want to remove non-existing files from the media-index.
 
 * `--generate-init`: Generate an init-script, write it to the standard output and exit afterwards. Any additional command-line arguments will be integrated into the generated script. See the [start on boot](#start-on-boot) section above for further details.
 
@@ -117,7 +117,7 @@ For a permanent solution it is recommended to add the line `fs.inotify.max_user_
 
 ### The media-index contains entries for files that do not exist
 
-To get rid of old files in the media-index, you might have to clear the whole media-index in the database and repopulate it afterwards. Since this requires to modify the database directly with SQL-commands, it is *strongly recommended* to crate a backup before executing the following commands to clear the media-index:
+To get rid of entries for non-existing files in the media-index, you have to clear the whole media-index and repopulate it afterwards. Since this requires to modify the database directly with SQL-commands, *it is strongly recommended to create a backup* before executing the following commands that clear the media-index tables:
 
 ```
 $ sudo synoservice --hard-stop synoindexd

--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ $ sudo synoservice --hard-stop synoindexd
 $ psql mediaserver -tAc "SELECT string_agg(tablename, ',') from pg_catalog.pg_tables WHERE tableowner = 'MediaIndex'"
 $ psql mediaserver -c  "TRUNCATE `psql mediaserver -tAc "SELECT string_agg(tablename, ',') from pg_catalog.pg_tables WHERE tableowner = 'MediaIndex'"` RESTART IDENTITY"
 $ sudo synoservice --start synoindexd"
+
 ```
 Afterwards you can use Synoindex Watcher to repopulate the media-index:
 
 ```
-$ synoindexwatcher --rebuild-index
+$ python -m synoindexwatcher --rebuild-index
 ```
+
 Make sure to add additional arguments like `--config` or the paths you want to watch.
 
 ----

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ To fix this temporarily you could simply type `echo 204800 > /proc/sys/fs/inotif
 
 For a permanent solution it is recommended to add the line `fs.inotify.max_user_watches = 204800` to the file */etc/sysctl.conf*. This should set the maximum value during boot, but I had to add an init-script that executes `sysctl -p /etc/sysctl.conf` to make it work. The simplest way would be to add the command to the start-section of the init-script for Synonindex Watcher.
 
+### The media-index contains entries for files that do not exist
+
+To get rid of old files in the media-index, you might have to clear the whole media-index in the database and repopulate it afterwards. Since this requires to modify the database directly with SQL-commands, it is *strongly recommended* to crate a backup before executing the following commands to clear the media-index:
+
+```
+$ sudo synoservice --hard-stop synoindexd
+$ psql mediaserver -tAc "SELECT string_agg(tablename, ',') from pg_catalog.pg_tables WHERE tableowner = 'MediaIndex'"
+$ psql mediaserver -c  "TRUNCATE `psql mediaserver -tAc "SELECT string_agg(tablename, ',') from pg_catalog.pg_tables WHERE tableowner = 'MediaIndex'"` RESTART IDENTITY"
+$ sudo synoservice --start synoindexd"
+```
+Afterwards you can use Synoindex Watcher to repopulate the media-index:
+
+```
+$ synoindexwatcher --rebuild-index
+```
+Make sure to add additional arguments like `--config` or the paths you want to watch.
+
 ----
 
 Copyright 2019 Torben Haase \<[https://pixelsvsbytes.com](https://pixelsvsbytes.com)>

--- a/synoindexwatcher/__main__.py
+++ b/synoindexwatcher/__main__.py
@@ -133,7 +133,7 @@ def parse_arguments(config):
     parser.add_argument("--config", default=None,
         help="read the default-configuration from the file CONFIG")
     parser.add_argument("--rebuild-index", action="store_true",
-        help="build a new media-index based on content of watched paths and exit")
+        help="add all allowed files and directories to the index and exit")
     parser.add_argument("--generate-config", action="store_true",
         help="generate and show a configuration-file and exit")
     parser.add_argument("--generate-init", action="store_true",

--- a/synoindexwatcher/__main__.py
+++ b/synoindexwatcher/__main__.py
@@ -57,17 +57,6 @@ def call_command(args):
     logging.debug("Calling '%s'" % " ".join(args))
     return subprocess.check_output(args, stderr=subprocess.STDOUT)
 
-def clear_index():
-    if os.path.exists("/var/spool/syno_indexing_queue") or os.path.exists("/var/spool/syno_indexing_queue.tmp"):
-        logging.error("Indexing in progress, aborting rebuild")
-        exit(3)
-    call_command(["sudo", "synoservice", "--hard-stop", "synoindexd"])
-    query = "SELECT string_agg(tablename, ',') from pg_catalog.pg_tables WHERE tableowner = 'MediaIndex'" 
-    tables = call_command(["psql", "mediaserver", "-tAc", query])
-    query = "TRUNCATE %s RESTART IDENTITY" % tables
-    call_command(["psql", "mediaserver", "-c", query])
-    call_command(["sudo", "synoservice", "--start", "synoindexd"])
-
 def add_to_index_recursive(fullpath):
     (path, name) = os.path.split(fullpath)
     __add_to_index_recursive(path, name)
@@ -171,16 +160,9 @@ def start():
         format="%(asctime)s %(levelname)s %(message)s")
 
     if args.rebuild_index:
-        print("The current media-index will be irrecoverably destroyed!")
-        confirmation = input("Enter 'yes' to continue or anything else to cancel: ")
-        if confirmation == "yes":
-            print("Clearing media-index database...")
-            clear_index()
-            print("Adding files to media-index (this may take some time)...")
-            for path in args.path:
-                add_to_index_recursive(path)
-        else:
-            print("Cancelled.")
+        print("Adding files to media-index (this may take some time)...")
+        for path in args.path:
+            add_to_index_recursive(path)
         return
 
     signal.signal(signal.SIGTERM, on_sigterm)


### PR DESCRIPTION
This PR moves the SQL-commands to clear the media-index database from the code. A FAQ entry that describes how to clear the media-index manually has been added to the readme.

Closes #40 